### PR TITLE
Issue #276: Enable to bulk clear ignore area for test runs list and details view.

### DIFF
--- a/src/components/TestDetailsModal.tsx
+++ b/src/components/TestDetailsModal.tsx
@@ -25,7 +25,7 @@ import { TestStatus } from "../types/testStatus";
 import { useHistory, Prompt } from "react-router-dom";
 import { IgnoreArea } from "../types/ignoreArea";
 import { KonvaEventObject } from "konva/types/Node";
-import { Close, Add, Delete, Save, WarningRounded } from "@material-ui/icons";
+import { Close, Add, Delete, Save, WarningRounded, LayersClear } from "@material-ui/icons";
 import { TestRunDetails } from "./TestRunDetails";
 import useImage from "use-image";
 import { routes } from "../constants";
@@ -330,7 +330,7 @@ const TestDetailsModal: React.FunctionComponent<{
               </Grid>
               <Grid item>
                 <IconButton
-                  disabled={!selectedRectId}
+                  disabled={!selectedRectId || ignoreAreas.length === 0}
                   onClick={() =>
                     selectedRectId && deleteIgnoreArea(selectedRectId)
                   }
@@ -338,6 +338,18 @@ const TestDetailsModal: React.FunctionComponent<{
                   <Delete />
                 </IconButton>
               </Grid>
+              <Tooltip title="Clears all ignore areas." aria-label="reject">
+                <Grid item>
+                  <IconButton
+                    disabled={ignoreAreas.length === 0}
+                    onClick={() =>
+                      setIgnoreAreas([])
+                    }
+                  >
+                    <LayersClear />
+                  </IconButton>
+                </Grid>
+              </Tooltip>
               <Grid item>
                 <IconButton
                   disabled={isIgnoreAreasSaved()}

--- a/src/components/TestRunList/BulkOperation.tsx
+++ b/src/components/TestRunList/BulkOperation.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { Typography, IconButton, Tooltip } from "@material-ui/core";
-import { BaseComponentProps, RowModel } from "@material-ui/data-grid";
+import { Typography, IconButton, Tooltip, LinearProgress } from "@material-ui/core";
+import { BaseComponentProps, InternalRowsState, RowModel } from "@material-ui/data-grid";
 import { BaseModal } from "../BaseModal";
 import { useSnackbar } from "notistack";
-import { Delete, ThumbDown, ThumbUp } from "@material-ui/icons";
+import { Collections, Delete, LayersClear, ThumbDown, ThumbUp } from "@material-ui/icons";
 import { testRunService } from "../../services";
 import { TestStatus } from "../../types";
+import { IgnoreArea } from "../../types/ignoreArea";
 
 export const BulkOperation: React.FunctionComponent<BaseComponentProps> = (
   props: BaseComponentProps
@@ -14,9 +15,13 @@ export const BulkOperation: React.FunctionComponent<BaseComponentProps> = (
   const [approveDialogOpen, setApproveDialogOpen] = React.useState(false);
   const [rejectDialogOpen, setRejectDialogOpen] = React.useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
+  const [applyIgnoreDialogOpen, setApplyIgnoreDialogOpen] = React.useState(false);
+  const [clearIgnoreDialogOpen, setClearIgnoreDialogOpen] = React.useState(false);
+  const [isProcessing, setIsProcessing] = React.useState(false);
 
-  const rows: Record<React.ReactText, boolean> = props.state.selection;
-  const count = Object.keys(rows).length;
+  const allRows: InternalRowsState = props.state.rows;
+  const selectedRows: Record<React.ReactText, boolean> = props.state.selection;
+  const count = Object.keys(selectedRows).length;
 
   const toggleApproveDialogOpen = () => {
     setApproveDialogOpen(!approveDialogOpen);
@@ -27,20 +32,38 @@ export const BulkOperation: React.FunctionComponent<BaseComponentProps> = (
   const toggleDeleteDialogOpen = () => {
     setDeleteDialogOpen(!deleteDialogOpen);
   };
+  const toggleApplyIgnoreDialogOpen = () => {
+    setApplyIgnoreDialogOpen(!applyIgnoreDialogOpen);
+  };
+  const toggleClearIgnoreDialogOpen = () => {
+    setClearIgnoreDialogOpen(!clearIgnoreDialogOpen);
+  };
 
   const getTitle = () => {
+    if (applyIgnoreDialogOpen) {
+      return "Apply Selected Ignore Area To All Images";
+    }
+    if (clearIgnoreDialogOpen) {
+      return "Clear Ignore Area For Selected Items";
+    }
     return submitButtonText() + " Test Runs";
   };
 
   const submitButtonText = (): string => {
-    if (deleteDialogOpen) {
-      return "Delete";
-    }
     if (approveDialogOpen) {
       return "Approve";
     }
     if (rejectDialogOpen) {
       return "Reject";
+    }
+    if (deleteDialogOpen) {
+      return "Delete";
+    }
+    if (applyIgnoreDialogOpen) {
+      return "Apply";
+    }
+    if (clearIgnoreDialogOpen) {
+      return "Clear";
     }
     return "";
   };
@@ -54,6 +77,12 @@ export const BulkOperation: React.FunctionComponent<BaseComponentProps> = (
     }
     if (rejectDialogOpen) {
       return toggleRejectDialogOpen();
+    }
+    if (applyIgnoreDialogOpen) {
+      return toggleApplyIgnoreDialogOpen();
+    }
+    if (clearIgnoreDialogOpen) {
+      return toggleClearIgnoreDialogOpen();
     }
   };
 
@@ -71,6 +100,23 @@ export const BulkOperation: React.FunctionComponent<BaseComponentProps> = (
     }
     if (isRowEligibleForApproveOrReject(id)) {
       processApproveReject(id);
+    }
+    if (clearIgnoreDialogOpen) {
+      testRunService.setIgnoreAreas(id, []);
+    }
+    if (applyIgnoreDialogOpen) {
+      const testRun = testRunService.getTestRunDetails(id);
+      let runningNumber = 0;
+      allRows.allRows.forEach(async (eachRow) => {
+        const ignoreAreaToSet: IgnoreArea[] = JSON.parse((await testRun).ignoreAreas);
+        if (ignoreAreaToSet.length > 0) {
+          //Add a running number to make id unique.
+          ignoreAreaToSet.forEach((e) => {
+            e.id = (Date.now() + (++runningNumber)).toString().slice(0, 13);
+          });
+          testRunService.setIgnoreAreas(eachRow.toString(), ignoreAreaToSet);
+        }
+      });
     }
   };
 
@@ -90,7 +136,20 @@ export const BulkOperation: React.FunctionComponent<BaseComponentProps> = (
     if (approveDialogOpen) {
       return toggleApproveDialogOpen();
     }
+    if (applyIgnoreDialogOpen) {
+      return toggleApplyIgnoreDialogOpen();
+    }
+    if (clearIgnoreDialogOpen) {
+      return toggleClearIgnoreDialogOpen();
+    }
     return toggleRejectDialogOpen();
+  };
+
+  const getProcessSuccessMessage = () => {
+    if (applyIgnoreDialogOpen) {
+      return "Selected image ignore area has been applied to all images.";
+    }
+    return `${count} test runs processed.`;
   };
 
   return (
@@ -116,28 +175,39 @@ export const BulkOperation: React.FunctionComponent<BaseComponentProps> = (
           </IconButton>
         </span>
       </Tooltip>
+      <Tooltip title="Applies ignore area from selected image to all images in this build." aria-label="apply ignore area">
+        <span>
+          <IconButton disabled={count !== 1} onClick={toggleApplyIgnoreDialogOpen}>
+            <Collections />
+          </IconButton>
+        </span>
+      </Tooltip>
+      <Tooltip title="Clear ignore areas for selected rows." aria-label="clear ignore area">
+        <span>
+          <IconButton disabled={count === 0} onClick={toggleClearIgnoreDialogOpen}>
+            <LayersClear />
+          </IconButton>
+        </span>
+      </Tooltip>
 
       <BaseModal
-        open={deleteDialogOpen || approveDialogOpen || rejectDialogOpen}
+        open={deleteDialogOpen || approveDialogOpen || rejectDialogOpen || applyIgnoreDialogOpen || clearIgnoreDialogOpen}
         title={getTitle()}
         submitButtonText={submitButtonText()}
         onCancel={dismissDialog}
         content={
-          <Typography>{`Are you sure you want to ${submitButtonText().toLowerCase()} ${count} items?`}</Typography>
+          <Typography>{applyIgnoreDialogOpen
+            ? `Are you sure you want to apply ignore area to all images? Works well if images are of same resolution.`
+            : `Are you sure you want to ${submitButtonText().toLowerCase()} ${count} items?`}</Typography>
         }
         onSubmit={() => {
-          enqueueSnackbar(
-            "Wait for the confirmation message until operation is completed.",
-            {
-              variant: "info",
-            }
-          );
-
+          setIsProcessing(true);
           Promise.all(
-            Object.keys(rows).map((id: string) => processAction(id))
+            Object.keys(selectedRows).map((id: string) => processAction(id))
           )
             .then(() => {
-              enqueueSnackbar(`${count} test runs processed.`, {
+              setIsProcessing(false);
+              enqueueSnackbar(getProcessSuccessMessage(), {
                 variant: "success",
               });
             })
@@ -149,6 +219,7 @@ export const BulkOperation: React.FunctionComponent<BaseComponentProps> = (
           closeModal();
         }}
       />
+      { isProcessing && <LinearProgress />}
     </>
   );
 };

--- a/src/services/testRun.service.ts
+++ b/src/services/testRun.service.ts
@@ -67,6 +67,18 @@ async function setIgnoreAreas(
   ).then(handleResponse);
 }
 
+async function getTestRunDetails(id: string): Promise<TestRun> {
+  const requestOptions = {
+    method: "GET",
+    headers: authHeader(),
+  };
+
+  return fetch(
+    `${API_URL}${ENDPOINT_URL}/${id}`,
+    requestOptions
+  ).then(handleResponse);
+}
+
 async function setComment(id: string, comment: string): Promise<TestRun> {
   const requestOptions = {
     method: "PUT",
@@ -84,6 +96,7 @@ export const testRunService = {
   remove,
   approve,
   reject,
+  getTestRunDetails,
   setIgnoreAreas,
   setComment,
 };

--- a/src/services/testRun.service.ts
+++ b/src/services/testRun.service.ts
@@ -67,18 +67,6 @@ async function setIgnoreAreas(
   ).then(handleResponse);
 }
 
-async function getTestRunDetails(id: string): Promise<TestRun> {
-  const requestOptions = {
-    method: "GET",
-    headers: authHeader(),
-  };
-
-  return fetch(
-    `${API_URL}${ENDPOINT_URL}/${id}`,
-    requestOptions
-  ).then(handleResponse);
-}
-
 async function setComment(id: string, comment: string): Promise<TestRun> {
   const requestOptions = {
     method: "PUT",
@@ -96,7 +84,6 @@ export const testRunService = {
   remove,
   approve,
   reject,
-  getTestRunDetails,
   setIgnoreAreas,
   setComment,
 };


### PR DESCRIPTION
Addresses issue https://github.com/Visual-Regression-Tracker/Visual-Regression-Tracker/issues/276
Changes included:

1. Clear icon will clear ignore area of the selected images.
2. ~~Apply ignore area icon will be enabled only one selection and then on confirming apply, it will apply the selected ignore area to all images in the build.~~
3. For small number of selection, both the "wait for processing" snackbar and success snackbar come almost at the same time which may confuse users. Replace this with a progress bar under the action icons.

~~I will raise a matching backend pull request if this is approved in principal. Here are some screenshots for reference.~~

<img width="363" alt="progressBar" src="https://user-images.githubusercontent.com/9042580/122616623-923e3700-d03f-11eb-9d3d-2973318fb609.png">

<img width="292" alt="newIconsWithTooltip" src="https://user-images.githubusercontent.com/9042580/122616642-98ccae80-d03f-11eb-8715-7ddb80f8eb8a.png">

<img width="596" alt="clearConfirmation" src="https://user-images.githubusercontent.com/9042580/122616653-9e29f900-d03f-11eb-9359-652ae854bcea.png">
