### PR TITLE
fix: check if relative path is specified in require_uri and return 403

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,6 +1,10 @@
 server {
   listen 8080;
 
+  if ($request_uri ~ "\.\./"){
+    return 403;
+  }
+
   location / {
     root /usr/share/nginx/html;
     index index.html index.htm;


### PR DESCRIPTION
Resolves [Issue #366](https://github.com/Visual-Regression-Tracker/Visual-Regression-Tracker/issues/366) 

Check if the relative path is specified in require_uri and return 403 before sending the request to be resolved by the server.

```
 if ($request_uri ~ "\.\./"){
  return 403;
 }
```

http://localhost:8080/?../../../../../../../../etc/hosts -> 403 forbidden
http://localhost:8080/?../../../../../../../../etc/passwd -> 403 forbidden

<img width="1088" alt="403-vrt" src="https://user-images.githubusercontent.com/12203794/181646407-50ae1e20-58b6-49d1-ab4e-37ced8688f0d.png">


This will prevent any directory traversal attempts. 
