### PR TITLE
fix: build fails to resolve jss-plugin-global under Vite

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,10 @@
 
     <title>Visual Regression Tracker</title>
 
+    <script>
+      // Polyfill for libraries (e.g. react-joyride) that expect the Node.js global object.
+      window.global = window;
+    </script>
     <script src="/env-config.js"></script>
   </head>
   <body>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,12 +4,6 @@ import react from "@vitejs/plugin-react";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  define: {
-    // Polyfill for Node.js 'global' object in browser environment
-    // Required for react-joyride and other libraries that expect Node.js globals
-    // This replaces all instances of 'global' with 'globalThis' at build time
-    global: "globalThis",
-  },
   server: {
     fs: {
       // Allow using "npm link" for packages when developing, that are in different base path


### PR DESCRIPTION
## What

Replaces the build-time `define: { global: "globalThis" }` in `vite.config.ts` with a runtime `window.global = window` shim in `index.html`.

## Why

Vite/esbuild `define` performs a textual token replacement across the bundle. It rewrites the token `global` **inside the import specifier** `"jss-plugin-global"` (pulled in by `@mui/styles/jssPreset`) into `"jss-plugin-globalThis"`, which does not exist, so the production build fails:

```
[vite]: Rollup failed to resolve import "jss-plugin-globalThis"
        from "node_modules/@mui/styles/jssPreset/jssPreset.js"
```

A runtime shim gives libraries that expect Node's `global` (e.g. react-joyride) what they need without rewriting source tokens, so the JSS import specifier stays intact.

## Test

`npm run build` fails with the `define` approach and passes with the runtime shim.
