### PR TITLE
feat: paginate test variation list with configurable page size

### DIFF
--- a/src/pages/TestVariationListPage.tsx
+++ b/src/pages/TestVariationListPage.tsx
@@ -3,7 +3,7 @@ import TestVariationList from "../components/TestVariationList";
 import { useNavigate, useParams } from "react-router-dom";
 import { TestVariation } from "../types";
 import { testVariationService } from "../services";
-import { Box, Grid } from "@mui/material";
+import { Box, Grid, Pagination, TextField, MenuItem } from "@mui/material";
 import ProjectSelect from "../components/ProjectSelect";
 import Filters from "../components/Filters";
 import { TestVariationMergeForm } from "../components/TestVariationMergeForm";
@@ -14,6 +14,8 @@ import {
   routes,
   TEST_VARIATION_LIST_PAGE,
 } from "../constants";
+
+const PAGE_SIZE_OPTIONS = [12, 24, 48, 96];
 
 const TestVariationListPage: React.FunctionComponent = () => {
   const navigate = useNavigate();
@@ -33,10 +35,16 @@ const TestVariationListPage: React.FunctionComponent = () => {
   const [customTags, setCustomTags] = React.useState("");
   const [branchName, setBranchName] = React.useState("");
   const [filteredItems, setFilteredItems] = React.useState<TestVariation[]>([]);
+  const [page, setPage] = React.useState(1);
+  const [pageSize, setPageSize] = React.useState(PAGE_SIZE_OPTIONS[0]);
 
   React.useEffect(() => {
     setHelpSteps(helpDispatch, TEST_VARIATION_LIST_PAGE);
   });
+
+  React.useEffect(() => {
+    setPage(1);
+  }, [query, os, device, browser, viewport, customTags, branchName]);
 
   React.useEffect(() => {
     if (projectId) {
@@ -93,6 +101,13 @@ const TestVariationListPage: React.FunctionComponent = () => {
       );
   };
 
+  const pageCount = Math.max(1, Math.ceil(filteredItems.length / pageSize));
+  const currentPage = Math.min(page, pageCount);
+  const paginatedItems = filteredItems.slice(
+    (currentPage - 1) * pageSize,
+    currentPage * pageSize,
+  );
+
   return (
     <React.Fragment>
       <Box m={2}>
@@ -127,10 +142,69 @@ const TestVariationListPage: React.FunctionComponent = () => {
           </Grid>
           <Grid item>
             <TestVariationList
-              items={filteredItems}
+              items={paginatedItems}
               onDeleteClick={handleDelete}
             />
           </Grid>
+          {filteredItems.length > Math.min(...PAGE_SIZE_OPTIONS) && (
+            <Grid item>
+              <Grid
+                container
+                justifyContent="center"
+                alignItems="center"
+                spacing={2}
+                sx={{ pb: 4 }}
+              >
+                {pageCount > 1 && (
+                  <Grid item>
+                    <Pagination
+                      count={pageCount}
+                      page={currentPage}
+                      onChange={(_event, value) => setPage(value)}
+                    />
+                  </Grid>
+                )}
+                <Grid item>
+                  <TextField
+                    select
+                    size="small"
+                    label="Per page"
+                    sx={{ minWidth: 120 }}
+                    SelectProps={{
+                      sx: {
+                        "& .MuiSelect-select": {
+                          textAlign: "center",
+                          pl: "32px",
+                        },
+                      },
+                    }}
+                    InputProps={{ notched: false }}
+                    InputLabelProps={{
+                      shrink: true,
+                      sx: {
+                        left: "50%",
+                        transformOrigin: "top center",
+                        transform: "translate(-50%, -9px) scale(0.75)",
+                        px: 0.5,
+                        bgcolor: "background.paper",
+                      },
+                    }}
+                    value={pageSize}
+                    onChange={(event) => {
+                      setPageSize(Number(event.target.value));
+                      setPage(1);
+                    }}
+                  >
+                    {PAGE_SIZE_OPTIONS.map((option) => (
+                      <MenuItem key={option} value={option}>
+                        {option}
+                      </MenuItem>
+                    ))}
+                  </TextField>
+                </Grid>
+              </Grid>
+            </Grid>
+          )}
         </Grid>
       </Box>
     </React.Fragment>


### PR DESCRIPTION
## Problem

The Test Variations page fetches and renders **every** variation of a project at once. On large projects this means thousands of MUI cards in the DOM, each triggering an image load — the page becomes unresponsive / fails to load.

## Change

Client-side pagination for the variation list:

- Render only the current page instead of the full list.
- Add a **Per page** selector (12 / 24 / 48 / 96), default 12.
- The pagination + page-size controls appear only when the number of filtered items exceeds the smallest page size; the page resets to the first when filters change.
- Existing filtering and the merge form are unchanged.

Purely client-side — no API or data-flow changes. Filtering still runs over the full fetched list, so results and the merge branch options are unaffected.

## Notes

- Scoped intentionally to rendering only. Server-side pagination (to also shrink the payload) can follow separately if needed.

## Screenshots
<img width="1591" height="416" alt="Screenshot 2026-07-13 at 14 55 49" src="https://github.com/user-attachments/assets/e3e07bce-1c91-4cb6-a6c3-31bd7f9e3a0c" />
<img width="1594" height="418" alt="Screenshot 2026-07-13 at 14 55 56" src="https://github.com/user-attachments/assets/80d94cb2-52cf-4ed3-8dc9-fa2782f5f683" />

