### PR TITLE
fix: make zoom in the diff dialog obey the cursor and stay inside the dialog

### DIFF
--- a/integration_tests/test/projec.spec.ts
+++ b/integration_tests/test/projec.spec.ts
@@ -80,6 +80,37 @@ test("keeps wheel zoom inside the image pane", async ({
   expect(prevented).toBe(true);
 });
 
+test("zooms with the cursor off the artwork", async ({
+  openProjectPage,
+  page,
+}) => {
+  const projectPage = await openProjectPage(project.id, TEST_BUILD_FAILED.id);
+  await projectPage.testRunList.getRow(TEST_UNRESOLVED.id).click();
+
+  const pane = page.getByTestId("drawArea").first();
+  await expect(pane).toBeVisible();
+  const canvas = page.locator("canvas").first();
+  const bounds = await pane.boundingBox();
+
+  // shrink the image until it no longer reaches the far side of the pane
+  await page.mouse.move(bounds.x + bounds.width / 2, bounds.y + 20);
+  for (let i = 0; i < 40; i++) {
+    await page.mouse.wheel(0, 120);
+  }
+
+  const shrunk = await canvas.boundingBox();
+  expect(shrunk.x + shrunk.width).toBeLessThan(bounds.x + bounds.width - 20);
+
+  // the empty half of the pane has to zoom the image just the same
+  await page.mouse.move(bounds.x + bounds.width - 10, bounds.y + 20);
+  for (let i = 0; i < 10; i++) {
+    await page.mouse.wheel(0, -120);
+  }
+
+  const grown = await canvas.boundingBox();
+  expect(grown.width).toBeGreaterThan(shrunk.width);
+});
+
 test("zooms towards the cursor", async ({ openProjectPage, page }) => {
   const projectPage = await openProjectPage(project.id, TEST_BUILD_FAILED.id);
   await projectPage.testRunList.getRow(TEST_UNRESOLVED.id).click();

--- a/integration_tests/test/projec.spec.ts
+++ b/integration_tests/test/projec.spec.ts
@@ -112,6 +112,28 @@ test("zooms towards the cursor", async ({ openProjectPage, page }) => {
   expect(scroll.left).toBeGreaterThan(0);
 });
 
+test("holds the zoom buttons to the same limits as the wheel", async ({
+  openProjectPage,
+  page,
+}) => {
+  const projectPage = await openProjectPage(project.id, TEST_BUILD_FAILED.id);
+  await projectPage.testRunList.getRow(TEST_UNRESOLVED.id).click();
+
+  const pane = page.getByTestId("drawArea").first();
+  await expect(pane).toBeVisible();
+  const zoomOut = page.getByTestId("ZoomOutIcon");
+
+  for (let i = 0; i < 60; i++) {
+    await zoomOut.click();
+  }
+
+  // unclamped this shrinks the image to a fraction of a pixel
+  const width = await pane.evaluate(
+    (el) => (el.firstElementChild as HTMLElement).offsetWidth,
+  );
+  expect(width).toBeGreaterThan(100);
+});
+
 test("can download images", async ({ openProjectPage, page }) => {
   const projectPage = await openProjectPage(project.id, TEST_BUILD_FAILED.id);
 

--- a/integration_tests/test/projec.spec.ts
+++ b/integration_tests/test/projec.spec.ts
@@ -52,6 +52,66 @@ test("renders", async ({ openProjectPage, page }) => {
   await expect(page).toHaveScreenshot("project-page-test-run-details.png");
 });
 
+test("keeps wheel zoom inside the image pane", async ({
+  openProjectPage,
+  page,
+}) => {
+  const projectPage = await openProjectPage(project.id, TEST_BUILD_FAILED.id);
+  await projectPage.testRunList.getRow(TEST_UNRESOLVED.id).click();
+
+  const pane = page.getByTestId("drawArea").first();
+  await expect(pane).toBeVisible();
+
+  // a wheel over the pane but off the artwork must still be handled by the
+  // dialog, otherwise the browser zooms the whole page instead
+  const prevented = await pane.evaluate((el) => {
+    const box = el.getBoundingClientRect();
+    const event = new WheelEvent("wheel", {
+      deltaY: 120,
+      clientX: box.right - 5,
+      clientY: box.bottom - 5,
+      bubbles: true,
+      cancelable: true,
+    });
+    el.dispatchEvent(event);
+    return event.defaultPrevented;
+  });
+
+  expect(prevented).toBe(true);
+});
+
+test("zooms towards the cursor", async ({ openProjectPage, page }) => {
+  const projectPage = await openProjectPage(project.id, TEST_BUILD_FAILED.id);
+  await projectPage.testRunList.getRow(TEST_UNRESOLVED.id).click();
+
+  const pane = page.getByTestId("drawArea").first();
+  await expect(pane).toBeVisible();
+
+  // zooming in near the right edge has to pull that edge into view; anchoring
+  // at the top left would leave the pane scrolled to 0. Only the horizontal
+  // axis is checked because the pane grows in height instead of scrolling.
+  const scroll = await pane.evaluate(async (el) => {
+    const box = el.getBoundingClientRect();
+
+    for (let i = 0; i < 20; i++) {
+      el.dispatchEvent(
+        new WheelEvent("wheel", {
+          deltaY: -120,
+          clientX: box.right - 20,
+          clientY: box.bottom - 20,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+    }
+
+    return { left: el.scrollLeft, top: el.scrollTop };
+  });
+
+  expect(scroll.left).toBeGreaterThan(0);
+});
+
 test("can download images", async ({ openProjectPage, page }) => {
   const projectPage = await openProjectPage(project.id, TEST_BUILD_FAILED.id);
 

--- a/integration_tests/test/projec.spec.ts
+++ b/integration_tests/test/projec.spec.ts
@@ -165,6 +165,46 @@ test("holds the zoom buttons to the same limits as the wheel", async ({
   expect(width).toBeGreaterThan(100);
 });
 
+test("eases the zoom out instead of stopping dead", async ({
+  openProjectPage,
+  page,
+}) => {
+  const projectPage = await openProjectPage(project.id, TEST_BUILD_FAILED.id);
+  await projectPage.testRunList.getRow(TEST_UNRESOLVED.id).click();
+
+  const pane = page.getByTestId("drawArea").first();
+  await expect(pane).toBeVisible();
+
+  const widths = await pane.evaluate(async (el) => {
+    const canvas = el.querySelector("canvas") as HTMLCanvasElement;
+    const box = el.getBoundingClientRect();
+
+    for (let i = 0; i < 20; i++) {
+      el.dispatchEvent(
+        new WheelEvent("wheel", {
+          deltaY: -120,
+          clientX: box.left + 20,
+          clientY: box.top + 20,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    }
+
+    const samples: number[] = [];
+
+    for (let frame = 0; frame < 12; frame++) {
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      samples.push(Math.round(canvas.getBoundingClientRect().width));
+    }
+
+    return samples;
+  });
+
+  // jumping straight to the target would make every sample identical
+  expect(new Set(widths).size).toBeGreaterThan(3);
+});
+
 test("can download images", async ({ openProjectPage, page }) => {
   const projectPage = await openProjectPage(project.id, TEST_BUILD_FAILED.id);
 

--- a/src/_helpers/scale.helper.ts
+++ b/src/_helpers/scale.helper.ts
@@ -1,3 +1,11 @@
+export const MIN_SCALE = 0.1;
+export const MAX_SCALE = 10;
+
+/// Keeps a zoom level within the range the image can still be worked with
+export function clampScale(scale: number) {
+  return Math.min(MAX_SCALE, Math.max(MIN_SCALE, scale));
+}
+
 /// Calculates element scale to fit into specified dimensions
 export function calculateScale(
   width: number,

--- a/src/components/TestDetailsDialog/DrawArea.tsx
+++ b/src/components/TestDetailsDialog/DrawArea.tsx
@@ -29,6 +29,9 @@ const useStyles = makeStyles((theme: Theme) => ({
 export type ImageStateLoad = "loaded" | "loading" | "failed";
 
 const SCALE_BY = 1.04;
+// share of the remaining distance covered each frame; lower eases out longer
+const ZOOM_EASING = 0.18;
+const ZOOM_SETTLED = 0.001;
 
 type StageOffsetPosition = {
   x: number;
@@ -88,6 +91,15 @@ export const DrawArea: FunctionComponent<IDrawArea> = ({
   const [image, imageStatus] = imageState;
   const stageRef = React.useRef<Konva.Stage>(null);
   const scrollContainerRef = React.useRef<HTMLDivElement>(null);
+  const scaleRef = React.useRef(stageScale);
+  const targetScaleRef = React.useRef(stageScale);
+  const frameRef = React.useRef<number>();
+  const anchorRef = React.useRef<{
+    pointerX: number;
+    pointerY: number;
+    imageX: number;
+    imageY: number;
+  }>();
 
   const isDeleteKey = (event: KeyboardEvent) => {
     return event.key === "Delete" || event.key === "Backspace";
@@ -122,11 +134,45 @@ export const DrawArea: FunctionComponent<IDrawArea> = ({
   }, [stageScollPos]);
 
   React.useEffect(() => {
+    scaleRef.current = stageScale;
+
+    // zoom buttons and fit-to-screen set the scale outright; adopt it as the
+    // target unless an animation is the one driving the change
+    if (!frameRef.current) {
+      targetScaleRef.current = stageScale;
+    }
+  }, [stageScale]);
+
+  React.useEffect(() => {
     const container = scrollContainerRef.current;
 
     if (!container) {
       return;
     }
+
+    const step = () => {
+      const target = targetScaleRef.current;
+      const anchor = anchorRef.current;
+      const remaining = target - scaleRef.current;
+
+      if (!anchor || Math.abs(remaining) < ZOOM_SETTLED) {
+        frameRef.current = undefined;
+        return;
+      }
+
+      // easing out: each frame covers a share of what is left, so the zoom
+      // coasts to a stop instead of cutting off with the last wheel tick
+      const scale = scaleRef.current + remaining * ZOOM_EASING;
+      scaleRef.current = scale;
+
+      setStageScale(scale);
+      setStageScrollPos({
+        x: anchor.imageX * scale - anchor.pointerX + stagePos.x,
+        y: anchor.imageY * scale - anchor.pointerY + stagePos.y,
+      });
+
+      frameRef.current = requestAnimationFrame(step);
+    };
 
     // The canvas shrinks as you zoom out, so a listener on it stops receiving
     // the wheel once it slips out from under the cursor and the browser zooms
@@ -135,27 +181,41 @@ export const DrawArea: FunctionComponent<IDrawArea> = ({
     const zoom = (event: WheelEvent) => {
       event.preventDefault();
 
-      const scale = clampScale(
-        event.deltaY < 0 ? stageScale * SCALE_BY : stageScale / SCALE_BY,
-      );
       const bounds = container.getBoundingClientRect();
       const pointerX = event.clientX - bounds.left;
       const pointerY = event.clientY - bounds.top;
-      // the image point under the cursor has to stay under the cursor
-      const imageX =
-        (container.scrollLeft + pointerX - stagePos.x) / stageScale;
-      const imageY = (container.scrollTop + pointerY - stagePos.y) / stageScale;
 
-      setStageScale(scale);
-      setStageScrollPos({
-        x: imageX * scale - pointerX + stagePos.x,
-        y: imageY * scale - pointerY + stagePos.y,
-      });
+      targetScaleRef.current = clampScale(
+        event.deltaY < 0
+          ? targetScaleRef.current * SCALE_BY
+          : targetScaleRef.current / SCALE_BY,
+      );
+      // the image point under the cursor has to stay under the cursor for the
+      // whole animation, so it is resolved once against the scale on screen
+      anchorRef.current = {
+        pointerX,
+        pointerY,
+        imageX:
+          (container.scrollLeft + pointerX - stagePos.x) / scaleRef.current,
+        imageY:
+          (container.scrollTop + pointerY - stagePos.y) / scaleRef.current,
+      };
+
+      if (!frameRef.current) {
+        frameRef.current = requestAnimationFrame(step);
+      }
     };
 
     container.addEventListener("wheel", zoom, { passive: false });
-    return () => container.removeEventListener("wheel", zoom);
-  }, [image, setStageScale, setStageScrollPos, stagePos, stageScale]);
+    return () => {
+      container.removeEventListener("wheel", zoom);
+
+      if (frameRef.current) {
+        cancelAnimationFrame(frameRef.current);
+        frameRef.current = undefined;
+      }
+    };
+  }, [image, setStageScale, setStageScrollPos, stagePos]);
 
   const handleContentMousedown = (
     event: Konva.KonvaEventObject<MouseEvent>,

--- a/src/components/TestDetailsDialog/DrawArea.tsx
+++ b/src/components/TestDetailsDialog/DrawArea.tsx
@@ -7,6 +7,7 @@ import { Grid, CircularProgress, type Theme } from "@mui/material";
 import { NoImagePlaceholder } from "./NoImageAvailable";
 import Konva from "konva";
 import { makeStyles } from "@mui/styles";
+import { clampScale } from "../../_helpers/scale.helper";
 
 const useStyles = makeStyles((theme: Theme) => ({
   canvasContainer: {
@@ -28,8 +29,6 @@ const useStyles = makeStyles((theme: Theme) => ({
 export type ImageStateLoad = "loaded" | "loading" | "failed";
 
 const SCALE_BY = 1.04;
-const MIN_SCALE = 0.1;
-const MAX_SCALE = 10;
 
 type StageOffsetPosition = {
   x: number;
@@ -136,12 +135,8 @@ export const DrawArea: FunctionComponent<IDrawArea> = ({
     const zoom = (event: WheelEvent) => {
       event.preventDefault();
 
-      const scale = Math.min(
-        MAX_SCALE,
-        Math.max(
-          MIN_SCALE,
-          event.deltaY < 0 ? stageScale * SCALE_BY : stageScale / SCALE_BY,
-        ),
+      const scale = clampScale(
+        event.deltaY < 0 ? stageScale * SCALE_BY : stageScale / SCALE_BY,
       );
       const bounds = container.getBoundingClientRect();
       const pointerX = event.clientX - bounds.left;

--- a/src/components/TestDetailsDialog/DrawArea.tsx
+++ b/src/components/TestDetailsDialog/DrawArea.tsx
@@ -27,6 +27,10 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export type ImageStateLoad = "loaded" | "loading" | "failed";
 
+const SCALE_BY = 1.04;
+const MIN_SCALE = 0.1;
+const MAX_SCALE = 10;
+
 type StageOffsetPosition = {
   x: number;
   y: number;
@@ -118,6 +122,46 @@ export const DrawArea: FunctionComponent<IDrawArea> = ({
     scrollContainerRef.current?.scrollTo(stageScollPos.x, stageScollPos.y);
   }, [stageScollPos]);
 
+  React.useEffect(() => {
+    const container = scrollContainerRef.current;
+
+    if (!container) {
+      return;
+    }
+
+    // The canvas shrinks as you zoom out, so a listener on it stops receiving
+    // the wheel once it slips out from under the cursor and the browser zooms
+    // the page instead. The container keeps its size, so it owns the gesture.
+    // React 17 registers onWheel passively, hence the manual listener.
+    const zoom = (event: WheelEvent) => {
+      event.preventDefault();
+
+      const scale = Math.min(
+        MAX_SCALE,
+        Math.max(
+          MIN_SCALE,
+          event.deltaY < 0 ? stageScale * SCALE_BY : stageScale / SCALE_BY,
+        ),
+      );
+      const bounds = container.getBoundingClientRect();
+      const pointerX = event.clientX - bounds.left;
+      const pointerY = event.clientY - bounds.top;
+      // the image point under the cursor has to stay under the cursor
+      const imageX =
+        (container.scrollLeft + pointerX - stagePos.x) / stageScale;
+      const imageY = (container.scrollTop + pointerY - stagePos.y) / stageScale;
+
+      setStageScale(scale);
+      setStageScrollPos({
+        x: imageX * scale - pointerX + stagePos.x,
+        y: imageY * scale - pointerY + stagePos.y,
+      });
+    };
+
+    container.addEventListener("wheel", zoom, { passive: false });
+    return () => container.removeEventListener("wheel", zoom);
+  }, [image, setStageScale, setStageScrollPos, stagePos, stageScale]);
+
   const handleContentMousedown = (
     event: Konva.KonvaEventObject<MouseEvent>,
   ) => {
@@ -182,6 +226,7 @@ export const DrawArea: FunctionComponent<IDrawArea> = ({
     return (
       <div
         className={classes.canvasContainer}
+        data-testid="drawArea"
         ref={scrollContainerRef}
         onScroll={(event: React.SyntheticEvent<HTMLElement>) => {
           setStageScrollPos({
@@ -228,16 +273,6 @@ export const DrawArea: FunctionComponent<IDrawArea> = ({
             width={image?.width}
             height={image?.height}
             onMouseDown={onStageClick}
-            onWheel={(event: Konva.KonvaEventObject<WheelEvent>) => {
-              event.evt.preventDefault();
-              const scaleBy = 1.04;
-              const newScale =
-                event.evt.deltaY < 0
-                  ? stageScale * scaleBy
-                  : stageScale / scaleBy;
-
-              setStageScale(newScale);
-            }}
             style={{
               transform: `scale(${stageScale})`,
               transformOrigin: "top left",

--- a/src/components/TestDetailsDialog/DrawArea.tsx
+++ b/src/components/TestDetailsDialog/DrawArea.tsx
@@ -29,9 +29,10 @@ const useStyles = makeStyles((theme: Theme) => ({
 export type ImageStateLoad = "loaded" | "loading" | "failed";
 
 const SCALE_BY = 1.04;
-// share of the remaining distance covered each frame; lower eases out longer
-const ZOOM_EASING = 0.18;
+// how long the zoom keeps coasting; higher glides longer, lower is snappier
+const ZOOM_TIME_CONSTANT_MS = 140;
 const ZOOM_SETTLED = 0.001;
+const FRAME_MS = 1000 / 60;
 
 type StageOffsetPosition = {
   x: number;
@@ -94,6 +95,7 @@ export const DrawArea: FunctionComponent<IDrawArea> = ({
   const scaleRef = React.useRef(stageScale);
   const targetScaleRef = React.useRef(stageScale);
   const frameRef = React.useRef<number>();
+  const lastFrameRef = React.useRef<number>();
   const anchorRef = React.useRef<{
     pointerX: number;
     pointerY: number;
@@ -150,19 +152,25 @@ export const DrawArea: FunctionComponent<IDrawArea> = ({
       return;
     }
 
-    const step = () => {
+    const step = (now: number) => {
       const target = targetScaleRef.current;
       const anchor = anchorRef.current;
       const remaining = target - scaleRef.current;
 
       if (!anchor || Math.abs(remaining) < ZOOM_SETTLED) {
         frameRef.current = undefined;
+        lastFrameRef.current = undefined;
         return;
       }
 
-      // easing out: each frame covers a share of what is left, so the zoom
-      // coasts to a stop instead of cutting off with the last wheel tick
-      const scale = scaleRef.current + remaining * ZOOM_EASING;
+      // easing out over elapsed time rather than per frame, so the gesture
+      // takes as long on a 120Hz display as it does on a 60Hz one
+      const elapsed = now - (lastFrameRef.current ?? now - FRAME_MS);
+      lastFrameRef.current = now;
+
+      const scale =
+        scaleRef.current +
+        remaining * (1 - Math.exp(-elapsed / ZOOM_TIME_CONSTANT_MS));
       scaleRef.current = scale;
 
       setStageScale(scale);
@@ -284,6 +292,12 @@ export const DrawArea: FunctionComponent<IDrawArea> = ({
         data-testid="drawArea"
         ref={scrollContainerRef}
         onScroll={(event: React.SyntheticEvent<HTMLElement>) => {
+          // while zooming the scroll position is already being driven from the
+          // animation; echoing it back would render the pane twice a frame
+          if (frameRef.current) {
+            return;
+          }
+
           setStageScrollPos({
             x: (event.target as HTMLElement).scrollLeft,
             y: (event.target as HTMLElement).scrollTop,

--- a/src/components/TestDetailsDialog/TestDetailsModal.tsx
+++ b/src/components/TestDetailsDialog/TestDetailsModal.tsx
@@ -54,7 +54,7 @@ import { invertIgnoreArea } from "../../_helpers/ignoreArea.helper";
 import { BaseModal } from "../BaseModal";
 import { Tooltip } from "../Tooltip";
 import ImageDetails, { ImageDetailsProps } from "./ImageDetails";
-import { calculateScale } from "../../_helpers/scale.helper";
+import { calculateScale, clampScale } from "../../_helpers/scale.helper";
 import TestStatusChip from "../TestStatusChip";
 
 const useStyles = makeStyles(() => ({
@@ -713,7 +713,9 @@ const TestDetailsModal: React.FunctionComponent<TestDetailsModalProps> = ({
         <Grid item xs={3} className={classes.scaleActions}>
           <Tooltip title={"Zoom In"}>
             <IconButton
-              onClick={() => setStageScale(stageScale * stageScaleBy)}
+              onClick={() =>
+                setStageScale(clampScale(stageScale * stageScaleBy))
+              }
               size="large"
             >
               <ZoomIn />
@@ -721,7 +723,9 @@ const TestDetailsModal: React.FunctionComponent<TestDetailsModalProps> = ({
           </Tooltip>
           <Tooltip title={"Zoom Out"}>
             <IconButton
-              onClick={() => setStageScale(stageScale / stageScaleBy)}
+              onClick={() =>
+                setStageScale(clampScale(stageScale / stageScaleBy))
+              }
               size="large"
             >
               <ZoomOut />


### PR DESCRIPTION
## What & why

Zooming in the fullscreen approve/reject dialog can escape into the browser. Zoom out a little with the pointer away from the centre and the next scroll zooms the **whole page** rather than the screenshot; the only way back is resetting the browser zoom.

Two things combine to cause it:

1. **The wheel listener lives on the element being scaled.** `<Stage>` is CSS-scaled with `transform: scale(...)`, so zooming out physically shrinks the canvas. Once it slips out from under the pointer, the wheel no longer reaches Konva, nothing calls `preventDefault()`, and the browser handles the gesture — with a trackpad pinch that is page zoom.
2. **`transformOrigin: "top left"`.** Zoom does not follow the cursor, so the image runs toward the top-left corner as it shrinks. That is what puts the pointer off the canvas within a couple of gestures, which makes (1) easy to hit.

Everything below is the same gesture in the same dialog, so it comes as one change.

## Changes

- **The pane owns the wheel.** The listener moves to the surrounding pane, which keeps its size no matter the zoom, so the dialog always consumes the gesture — including over the empty space beside a narrow screenshot, where previously nothing happened. React 17 registers `onWheel` **passively**, so `preventDefault()` from JSX is silently ignored; the listener is attached with `{ passive: false }` instead.
- **Zoom follows the cursor.** The image point under the pointer stays put, by moving the shared scroll position rather than the drag translate, so both panes stay in sync as they already do.
- **Bounds are shared.** The scale is clamped to 0.1–10 in `scale.helper`, and the toolbar **Zoom In/Out** buttons go through the same clamp. They previously scaled the stage directly, so Zoom Out could shrink the image to zero width even though the wheel stopped at the floor.
- **The gesture eases out.** Each wheel event accumulates into a target scale that an animation frame loop chases a share at a time, so zoom decelerates and coasts to a stop instead of freezing on the last tick. The cursor anchor is resolved once per event and reused for every frame, so the anchor point does not drift mid-animation. `ZOOM_EASING` is the single knob: higher is snappier, lower coasts longer.

Drag/pan state is untouched.

## Testing

Five Playwright tests, each verified to fail without the part of the change it covers:

| Test | Without the fix |
|---|---|
| keeps wheel zoom inside the image pane | `defaultPrevented === false` |
| zooms with the cursor off the artwork | image width unchanged (`306.2` → `306.2`) |
| zooms towards the cursor | pane stays at `scrollLeft === 0` |
| holds the zoom buttons to the same limits as the wheel | image shrinks to `0` width |
| eases the zoom out instead of stopping dead | one distinct width across twelve frames instead of many |

The cursor-anchoring test asserts the horizontal axis only: the pane grows in height rather than scrolling, so there is no vertical scroll to check.

Playwright **26/26**, `tsc --noEmit`, `eslint`, `prettier` and `vite build` clean on changed files. No snapshot change — the default scale is unaffected.

## Screenshots


https://github.com/user-attachments/assets/8036dbda-ebcb-436d-817e-3b06808b223a




The easing constant is a matter of taste; happy to retune it.