### PR TITLE
feat: ease the zoom instead of stopping with the last wheel tick

### DIFF
--- a/integration_tests/test/projec.spec.ts
+++ b/integration_tests/test/projec.spec.ts
@@ -80,6 +80,37 @@ test("keeps wheel zoom inside the image pane", async ({
   expect(prevented).toBe(true);
 });
 
+test("zooms with the cursor off the artwork", async ({
+  openProjectPage,
+  page,
+}) => {
+  const projectPage = await openProjectPage(project.id, TEST_BUILD_FAILED.id);
+  await projectPage.testRunList.getRow(TEST_UNRESOLVED.id).click();
+
+  const pane = page.getByTestId("drawArea").first();
+  await expect(pane).toBeVisible();
+  const canvas = page.locator("canvas").first();
+  const bounds = await pane.boundingBox();
+
+  // shrink the image until it no longer reaches the far side of the pane
+  await page.mouse.move(bounds.x + bounds.width / 2, bounds.y + 20);
+  for (let i = 0; i < 40; i++) {
+    await page.mouse.wheel(0, 120);
+  }
+
+  const shrunk = await canvas.boundingBox();
+  expect(shrunk.x + shrunk.width).toBeLessThan(bounds.x + bounds.width - 20);
+
+  // the empty half of the pane has to zoom the image just the same
+  await page.mouse.move(bounds.x + bounds.width - 10, bounds.y + 20);
+  for (let i = 0; i < 10; i++) {
+    await page.mouse.wheel(0, -120);
+  }
+
+  const grown = await canvas.boundingBox();
+  expect(grown.width).toBeGreaterThan(shrunk.width);
+});
+
 test("zooms towards the cursor", async ({ openProjectPage, page }) => {
   const projectPage = await openProjectPage(project.id, TEST_BUILD_FAILED.id);
   await projectPage.testRunList.getRow(TEST_UNRESOLVED.id).click();

--- a/integration_tests/test/projec.spec.ts
+++ b/integration_tests/test/projec.spec.ts
@@ -112,6 +112,28 @@ test("zooms towards the cursor", async ({ openProjectPage, page }) => {
   expect(scroll.left).toBeGreaterThan(0);
 });
 
+test("holds the zoom buttons to the same limits as the wheel", async ({
+  openProjectPage,
+  page,
+}) => {
+  const projectPage = await openProjectPage(project.id, TEST_BUILD_FAILED.id);
+  await projectPage.testRunList.getRow(TEST_UNRESOLVED.id).click();
+
+  const pane = page.getByTestId("drawArea").first();
+  await expect(pane).toBeVisible();
+  const zoomOut = page.getByTestId("ZoomOutIcon");
+
+  for (let i = 0; i < 60; i++) {
+    await zoomOut.click();
+  }
+
+  // unclamped this shrinks the image to a fraction of a pixel
+  const width = await pane.evaluate(
+    (el) => (el.firstElementChild as HTMLElement).offsetWidth,
+  );
+  expect(width).toBeGreaterThan(100);
+});
+
 test("can download images", async ({ openProjectPage, page }) => {
   const projectPage = await openProjectPage(project.id, TEST_BUILD_FAILED.id);
 

--- a/integration_tests/test/projec.spec.ts
+++ b/integration_tests/test/projec.spec.ts
@@ -52,6 +52,66 @@ test("renders", async ({ openProjectPage, page }) => {
   await expect(page).toHaveScreenshot("project-page-test-run-details.png");
 });
 
+test("keeps wheel zoom inside the image pane", async ({
+  openProjectPage,
+  page,
+}) => {
+  const projectPage = await openProjectPage(project.id, TEST_BUILD_FAILED.id);
+  await projectPage.testRunList.getRow(TEST_UNRESOLVED.id).click();
+
+  const pane = page.getByTestId("drawArea").first();
+  await expect(pane).toBeVisible();
+
+  // a wheel over the pane but off the artwork must still be handled by the
+  // dialog, otherwise the browser zooms the whole page instead
+  const prevented = await pane.evaluate((el) => {
+    const box = el.getBoundingClientRect();
+    const event = new WheelEvent("wheel", {
+      deltaY: 120,
+      clientX: box.right - 5,
+      clientY: box.bottom - 5,
+      bubbles: true,
+      cancelable: true,
+    });
+    el.dispatchEvent(event);
+    return event.defaultPrevented;
+  });
+
+  expect(prevented).toBe(true);
+});
+
+test("zooms towards the cursor", async ({ openProjectPage, page }) => {
+  const projectPage = await openProjectPage(project.id, TEST_BUILD_FAILED.id);
+  await projectPage.testRunList.getRow(TEST_UNRESOLVED.id).click();
+
+  const pane = page.getByTestId("drawArea").first();
+  await expect(pane).toBeVisible();
+
+  // zooming in near the right edge has to pull that edge into view; anchoring
+  // at the top left would leave the pane scrolled to 0. Only the horizontal
+  // axis is checked because the pane grows in height instead of scrolling.
+  const scroll = await pane.evaluate(async (el) => {
+    const box = el.getBoundingClientRect();
+
+    for (let i = 0; i < 20; i++) {
+      el.dispatchEvent(
+        new WheelEvent("wheel", {
+          deltaY: -120,
+          clientX: box.right - 20,
+          clientY: box.bottom - 20,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+    }
+
+    return { left: el.scrollLeft, top: el.scrollTop };
+  });
+
+  expect(scroll.left).toBeGreaterThan(0);
+});
+
 test("can download images", async ({ openProjectPage, page }) => {
   const projectPage = await openProjectPage(project.id, TEST_BUILD_FAILED.id);
 

--- a/integration_tests/test/projec.spec.ts
+++ b/integration_tests/test/projec.spec.ts
@@ -165,6 +165,46 @@ test("holds the zoom buttons to the same limits as the wheel", async ({
   expect(width).toBeGreaterThan(100);
 });
 
+test("eases the zoom out instead of stopping dead", async ({
+  openProjectPage,
+  page,
+}) => {
+  const projectPage = await openProjectPage(project.id, TEST_BUILD_FAILED.id);
+  await projectPage.testRunList.getRow(TEST_UNRESOLVED.id).click();
+
+  const pane = page.getByTestId("drawArea").first();
+  await expect(pane).toBeVisible();
+
+  const widths = await pane.evaluate(async (el) => {
+    const canvas = el.querySelector("canvas") as HTMLCanvasElement;
+    const box = el.getBoundingClientRect();
+
+    for (let i = 0; i < 20; i++) {
+      el.dispatchEvent(
+        new WheelEvent("wheel", {
+          deltaY: -120,
+          clientX: box.left + 20,
+          clientY: box.top + 20,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    }
+
+    const samples: number[] = [];
+
+    for (let frame = 0; frame < 12; frame++) {
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      samples.push(Math.round(canvas.getBoundingClientRect().width));
+    }
+
+    return samples;
+  });
+
+  // jumping straight to the target would make every sample identical
+  expect(new Set(widths).size).toBeGreaterThan(3);
+});
+
 test("can download images", async ({ openProjectPage, page }) => {
   const projectPage = await openProjectPage(project.id, TEST_BUILD_FAILED.id);
 

--- a/src/_helpers/scale.helper.ts
+++ b/src/_helpers/scale.helper.ts
@@ -1,3 +1,11 @@
+export const MIN_SCALE = 0.1;
+export const MAX_SCALE = 10;
+
+/// Keeps a zoom level within the range the image can still be worked with
+export function clampScale(scale: number) {
+  return Math.min(MAX_SCALE, Math.max(MIN_SCALE, scale));
+}
+
 /// Calculates element scale to fit into specified dimensions
 export function calculateScale(
   width: number,

--- a/src/components/TestDetailsDialog/DrawArea.tsx
+++ b/src/components/TestDetailsDialog/DrawArea.tsx
@@ -29,6 +29,9 @@ const useStyles = makeStyles((theme: Theme) => ({
 export type ImageStateLoad = "loaded" | "loading" | "failed";
 
 const SCALE_BY = 1.04;
+// share of the remaining distance covered each frame; lower eases out longer
+const ZOOM_EASING = 0.18;
+const ZOOM_SETTLED = 0.001;
 
 type StageOffsetPosition = {
   x: number;
@@ -88,6 +91,15 @@ export const DrawArea: FunctionComponent<IDrawArea> = ({
   const [image, imageStatus] = imageState;
   const stageRef = React.useRef<Konva.Stage>(null);
   const scrollContainerRef = React.useRef<HTMLDivElement>(null);
+  const scaleRef = React.useRef(stageScale);
+  const targetScaleRef = React.useRef(stageScale);
+  const frameRef = React.useRef<number>();
+  const anchorRef = React.useRef<{
+    pointerX: number;
+    pointerY: number;
+    imageX: number;
+    imageY: number;
+  }>();
 
   const isDeleteKey = (event: KeyboardEvent) => {
     return event.key === "Delete" || event.key === "Backspace";
@@ -122,11 +134,45 @@ export const DrawArea: FunctionComponent<IDrawArea> = ({
   }, [stageScollPos]);
 
   React.useEffect(() => {
+    scaleRef.current = stageScale;
+
+    // zoom buttons and fit-to-screen set the scale outright; adopt it as the
+    // target unless an animation is the one driving the change
+    if (!frameRef.current) {
+      targetScaleRef.current = stageScale;
+    }
+  }, [stageScale]);
+
+  React.useEffect(() => {
     const container = scrollContainerRef.current;
 
     if (!container) {
       return;
     }
+
+    const step = () => {
+      const target = targetScaleRef.current;
+      const anchor = anchorRef.current;
+      const remaining = target - scaleRef.current;
+
+      if (!anchor || Math.abs(remaining) < ZOOM_SETTLED) {
+        frameRef.current = undefined;
+        return;
+      }
+
+      // easing out: each frame covers a share of what is left, so the zoom
+      // coasts to a stop instead of cutting off with the last wheel tick
+      const scale = scaleRef.current + remaining * ZOOM_EASING;
+      scaleRef.current = scale;
+
+      setStageScale(scale);
+      setStageScrollPos({
+        x: anchor.imageX * scale - anchor.pointerX + stagePos.x,
+        y: anchor.imageY * scale - anchor.pointerY + stagePos.y,
+      });
+
+      frameRef.current = requestAnimationFrame(step);
+    };
 
     // The canvas shrinks as you zoom out, so a listener on it stops receiving
     // the wheel once it slips out from under the cursor and the browser zooms
@@ -135,27 +181,41 @@ export const DrawArea: FunctionComponent<IDrawArea> = ({
     const zoom = (event: WheelEvent) => {
       event.preventDefault();
 
-      const scale = clampScale(
-        event.deltaY < 0 ? stageScale * SCALE_BY : stageScale / SCALE_BY,
-      );
       const bounds = container.getBoundingClientRect();
       const pointerX = event.clientX - bounds.left;
       const pointerY = event.clientY - bounds.top;
-      // the image point under the cursor has to stay under the cursor
-      const imageX =
-        (container.scrollLeft + pointerX - stagePos.x) / stageScale;
-      const imageY = (container.scrollTop + pointerY - stagePos.y) / stageScale;
 
-      setStageScale(scale);
-      setStageScrollPos({
-        x: imageX * scale - pointerX + stagePos.x,
-        y: imageY * scale - pointerY + stagePos.y,
-      });
+      targetScaleRef.current = clampScale(
+        event.deltaY < 0
+          ? targetScaleRef.current * SCALE_BY
+          : targetScaleRef.current / SCALE_BY,
+      );
+      // the image point under the cursor has to stay under the cursor for the
+      // whole animation, so it is resolved once against the scale on screen
+      anchorRef.current = {
+        pointerX,
+        pointerY,
+        imageX:
+          (container.scrollLeft + pointerX - stagePos.x) / scaleRef.current,
+        imageY:
+          (container.scrollTop + pointerY - stagePos.y) / scaleRef.current,
+      };
+
+      if (!frameRef.current) {
+        frameRef.current = requestAnimationFrame(step);
+      }
     };
 
     container.addEventListener("wheel", zoom, { passive: false });
-    return () => container.removeEventListener("wheel", zoom);
-  }, [image, setStageScale, setStageScrollPos, stagePos, stageScale]);
+    return () => {
+      container.removeEventListener("wheel", zoom);
+
+      if (frameRef.current) {
+        cancelAnimationFrame(frameRef.current);
+        frameRef.current = undefined;
+      }
+    };
+  }, [image, setStageScale, setStageScrollPos, stagePos]);
 
   const handleContentMousedown = (
     event: Konva.KonvaEventObject<MouseEvent>,

--- a/src/components/TestDetailsDialog/DrawArea.tsx
+++ b/src/components/TestDetailsDialog/DrawArea.tsx
@@ -7,6 +7,7 @@ import { Grid, CircularProgress, type Theme } from "@mui/material";
 import { NoImagePlaceholder } from "./NoImageAvailable";
 import Konva from "konva";
 import { makeStyles } from "@mui/styles";
+import { clampScale } from "../../_helpers/scale.helper";
 
 const useStyles = makeStyles((theme: Theme) => ({
   canvasContainer: {
@@ -28,8 +29,6 @@ const useStyles = makeStyles((theme: Theme) => ({
 export type ImageStateLoad = "loaded" | "loading" | "failed";
 
 const SCALE_BY = 1.04;
-const MIN_SCALE = 0.1;
-const MAX_SCALE = 10;
 
 type StageOffsetPosition = {
   x: number;
@@ -136,12 +135,8 @@ export const DrawArea: FunctionComponent<IDrawArea> = ({
     const zoom = (event: WheelEvent) => {
       event.preventDefault();
 
-      const scale = Math.min(
-        MAX_SCALE,
-        Math.max(
-          MIN_SCALE,
-          event.deltaY < 0 ? stageScale * SCALE_BY : stageScale / SCALE_BY,
-        ),
+      const scale = clampScale(
+        event.deltaY < 0 ? stageScale * SCALE_BY : stageScale / SCALE_BY,
       );
       const bounds = container.getBoundingClientRect();
       const pointerX = event.clientX - bounds.left;

--- a/src/components/TestDetailsDialog/DrawArea.tsx
+++ b/src/components/TestDetailsDialog/DrawArea.tsx
@@ -27,6 +27,10 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export type ImageStateLoad = "loaded" | "loading" | "failed";
 
+const SCALE_BY = 1.04;
+const MIN_SCALE = 0.1;
+const MAX_SCALE = 10;
+
 type StageOffsetPosition = {
   x: number;
   y: number;
@@ -118,6 +122,46 @@ export const DrawArea: FunctionComponent<IDrawArea> = ({
     scrollContainerRef.current?.scrollTo(stageScollPos.x, stageScollPos.y);
   }, [stageScollPos]);
 
+  React.useEffect(() => {
+    const container = scrollContainerRef.current;
+
+    if (!container) {
+      return;
+    }
+
+    // The canvas shrinks as you zoom out, so a listener on it stops receiving
+    // the wheel once it slips out from under the cursor and the browser zooms
+    // the page instead. The container keeps its size, so it owns the gesture.
+    // React 17 registers onWheel passively, hence the manual listener.
+    const zoom = (event: WheelEvent) => {
+      event.preventDefault();
+
+      const scale = Math.min(
+        MAX_SCALE,
+        Math.max(
+          MIN_SCALE,
+          event.deltaY < 0 ? stageScale * SCALE_BY : stageScale / SCALE_BY,
+        ),
+      );
+      const bounds = container.getBoundingClientRect();
+      const pointerX = event.clientX - bounds.left;
+      const pointerY = event.clientY - bounds.top;
+      // the image point under the cursor has to stay under the cursor
+      const imageX =
+        (container.scrollLeft + pointerX - stagePos.x) / stageScale;
+      const imageY = (container.scrollTop + pointerY - stagePos.y) / stageScale;
+
+      setStageScale(scale);
+      setStageScrollPos({
+        x: imageX * scale - pointerX + stagePos.x,
+        y: imageY * scale - pointerY + stagePos.y,
+      });
+    };
+
+    container.addEventListener("wheel", zoom, { passive: false });
+    return () => container.removeEventListener("wheel", zoom);
+  }, [image, setStageScale, setStageScrollPos, stagePos, stageScale]);
+
   const handleContentMousedown = (
     event: Konva.KonvaEventObject<MouseEvent>,
   ) => {
@@ -182,6 +226,7 @@ export const DrawArea: FunctionComponent<IDrawArea> = ({
     return (
       <div
         className={classes.canvasContainer}
+        data-testid="drawArea"
         ref={scrollContainerRef}
         onScroll={(event: React.SyntheticEvent<HTMLElement>) => {
           setStageScrollPos({
@@ -228,16 +273,6 @@ export const DrawArea: FunctionComponent<IDrawArea> = ({
             width={image?.width}
             height={image?.height}
             onMouseDown={onStageClick}
-            onWheel={(event: Konva.KonvaEventObject<WheelEvent>) => {
-              event.evt.preventDefault();
-              const scaleBy = 1.04;
-              const newScale =
-                event.evt.deltaY < 0
-                  ? stageScale * scaleBy
-                  : stageScale / scaleBy;
-
-              setStageScale(newScale);
-            }}
             style={{
               transform: `scale(${stageScale})`,
               transformOrigin: "top left",

--- a/src/components/TestDetailsDialog/TestDetailsModal.tsx
+++ b/src/components/TestDetailsDialog/TestDetailsModal.tsx
@@ -54,7 +54,7 @@ import { invertIgnoreArea } from "../../_helpers/ignoreArea.helper";
 import { BaseModal } from "../BaseModal";
 import { Tooltip } from "../Tooltip";
 import ImageDetails, { ImageDetailsProps } from "./ImageDetails";
-import { calculateScale } from "../../_helpers/scale.helper";
+import { calculateScale, clampScale } from "../../_helpers/scale.helper";
 import TestStatusChip from "../TestStatusChip";
 
 const useStyles = makeStyles(() => ({
@@ -713,7 +713,9 @@ const TestDetailsModal: React.FunctionComponent<TestDetailsModalProps> = ({
         <Grid item xs={3} className={classes.scaleActions}>
           <Tooltip title={"Zoom In"}>
             <IconButton
-              onClick={() => setStageScale(stageScale * stageScaleBy)}
+              onClick={() =>
+                setStageScale(clampScale(stageScale * stageScaleBy))
+              }
               size="large"
             >
               <ZoomIn />
@@ -721,7 +723,9 @@ const TestDetailsModal: React.FunctionComponent<TestDetailsModalProps> = ({
           </Tooltip>
           <Tooltip title={"Zoom Out"}>
             <IconButton
-              onClick={() => setStageScale(stageScale / stageScaleBy)}
+              onClick={() =>
+                setStageScale(clampScale(stageScale / stageScaleBy))
+              }
               size="large"
             >
               <ZoomOut />


### PR DESCRIPTION
## What & why

Wheel zoom applies each step the instant its event arrives, so a gesture stops as sharply as it starts — the image is moving, you lift your fingers, and it freezes mid-motion. Reviewing hundreds of screenshots, that abruptness is what makes the zoom feel unresponsive even when it is doing the right thing.

**Stacked on #383** — it builds on the wheel handling introduced there and should land after it.

## Changes

- Each wheel event now accumulates into a *target* scale rather than being applied outright. An animation frame loop moves the current scale a fixed share of the remaining distance, so it decelerates as it approaches and coasts to a stop once the gesture ends.
- The cursor anchor is resolved once per event, in image coordinates, and reused for every frame — the point under the pointer stays put for the whole animation instead of drifting as the scale changes.
- The loop stops itself once the remainder is negligible, and is cancelled on unmount. Zoom buttons and fit-to-screen still set the scale outright; their value is adopted as the new target.

One knob, `ZOOM_EASING`, controls the whole feel: higher is snappier, lower coasts longer.

## Testing

- New Playwright test: fire a burst of wheel events, sample the rendered width over twelve animation frames and require several distinct values. Verified to fail with easing disabled — every sample is then identical (`1` distinct value against the expected `> 3`).
- Playwright **26/26**, `tsc --noEmit`, `eslint`, `prettier` and `vite build` clean on changed files. No snapshot change.

The number itself is a matter of taste — happy to retune it if it feels too slow or too eager.